### PR TITLE
Call super() before accessing "mailman" attribute in filebased backend

### DIFF
--- a/flask_mailman/backends/filebased.py
+++ b/flask_mailman/backends/filebased.py
@@ -15,6 +15,10 @@ class ImproperlyConfigured(Exception):
 
 class EmailBackend(ConsoleEmailBackend):
     def __init__(self, *args, file_path=None, **kwargs):
+        # Since we're using the console-based backend as a base,
+        # force the stream to be None, so we don't default to stdout
+        kwargs['stream'] = None
+        super().__init__(*args, **kwargs)
         self._fname = None
         if file_path is not None:
             self.file_path = file_path
@@ -40,11 +44,6 @@ class EmailBackend(ConsoleEmailBackend):
         # Make sure that self.file_path is writable.
         if not os.access(self.file_path, os.W_OK):
             raise ImproperlyConfigured('Could not write to directory: %s' % self.file_path)
-        # Finally, call super().
-        # Since we're using the console-based backend as a base,
-        # force the stream to be None, so we don't default to stdout
-        kwargs['stream'] = None
-        super().__init__(*args, **kwargs)
 
     def write_message(self, message):
         self.stream.write(message.message().as_bytes() + b'\n')


### PR DESCRIPTION
This fixes:

    Traceback (most recent call last):
      [...]
        app.mail.send(msg)
      File ".../lib64/python3.6/site-packages/flask_mailman/__init__.py", line 76, in send
        mail.connection = self.get_connection(fail_silently=fail_silently)
      File ".../lib64/python3.6/site-packages/flask_mailman/__init__.py", line 62, in get_connection
        return klass(mailman=mailman, fail_silently=fail_silently, **kwds)
      File ".../lib64/python3.6/site-packages/flask_mailman/backends/filebased.py", line 22, in __init__
        self.file_path = self.mailman.file_path
    AttributeError: 'EmailBackend' object has no attribute 'mailman'

Namely, since filebased.EmailBackend() is not instantiated with a
'file_path' argument from _MailMixin.get_connection(), the 'file_path'
attribute in the former class is retrieved from the 'mailman' attribute
which is set in parent class's __init__. By calling super() early, we
make sure the 'mailman' attribute will be set.