### PR TITLE
set default None for the from_email and recipient_list of send_mail()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Flask-Mailman
 
+![PyPI - Downloads](https://img.shields.io/pypi/dm/flask-mailman)
+![PyPI - License](https://img.shields.io/pypi/l/flask-mailman)
+
 Flask-Mailman is a Flask extension providing simple email sending capabilities.
 
 It was meant to replace unmaintained Flask-Mail with a better warranty and more features.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.2.2
+
+### Changed
+
+- Set `None` as the default value for the `from_email` and `recipient_list` of `send_mail()` function.
+
 ## 0.2.0
 
 A few breaking changes have been made in this version to ensure that API of this extension is basically the same as Django. 

--- a/flask_mailman/__init__.py
+++ b/flask_mailman/__init__.py
@@ -60,7 +60,7 @@ class _MailMixin(object):
 
         return klass(mailman=mailman, fail_silently=fail_silently, **kwds)
 
-    def send_mail(self, subject, message, from_email, recipient_list,
+    def send_mail(self, subject, message, from_email=None, recipient_list=None,
                   fail_silently=False, auth_user=None, auth_password=None,
                   connection=None, html_message=None):
         """
@@ -69,9 +69,6 @@ class _MailMixin(object):
 
         If auth_user is None, use the MAIL_USERNAME setting.
         If auth_password is None, use the MAIL_PASSWORD setting.
-
-        Note: The API for this method is frozen. New code wanting to extend the
-        functionality should use the EmailMessage class directly.
         """
         connection = connection or self.get_connection(
             username=auth_user,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Flask-Mailman"
-version = "0.2.1"
+version = "0.2.2"
 description = "Porting Django's email implementation to your Flask applications."
 authors = ["Waynerv <ampedee@gmail.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
Resolve #11.

Fully compatible with previous versions