### PR TITLE
update supported Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,10 @@ classifiers=[
         "Topic :: Software Development :: Build Tools",
         "Topic :: Communications :: Email",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
- remove Python3.5 from classifiers, as it was not supported any longer
anyways
- add support for Python 3.8 and 3.9