### PR TITLE
Use random module to produce an actually unique file name

### DIFF
--- a/flask_mailman/backends/file.py
+++ b/flask_mailman/backends/file.py
@@ -2,6 +2,7 @@
 
 import datetime
 import os
+import random
 
 from flask_mailman.backends.console import EmailBackend as ConsoleEmailBackend
 
@@ -47,7 +48,7 @@ class EmailBackend(ConsoleEmailBackend):
         """Return a unique file name."""
         if self._fname is None:
             timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-            fname = "%s-%s.log" % (timestamp, abs(id(self)))
+            fname = "%s-%s.log" % (timestamp, random.randrange(1e15))
             self._fname = os.path.join(self.file_path, fname)
         return self._fname
 


### PR DESCRIPTION
During tests I noticed that flask_mailman would not produce one log file per message but actually sometimes append a message to an existing mail log file. By looking at the code I noticed that the file name of the log is derived from the ID of the object which might be reused (see also https://stackoverflow.com/q/20753364/172822 for a discussion). To get a truly unique file name I changed the code so that `randrange()` is used.