### PR TITLE
Fix compatibility with Python 3.10

### DIFF
--- a/flask_mailman/backends/file.py
+++ b/flask_mailman/backends/file.py
@@ -48,7 +48,7 @@ class EmailBackend(ConsoleEmailBackend):
         """Return a unique file name."""
         if self._fname is None:
             timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-            fname = "%s-%s.log" % (timestamp, random.randrange(1e15))
+            fname = "%s-%s.log" % (timestamp, random.randrange(int(1e15)))
             self._fname = os.path.join(self.file_path, fname)
         return self._fname
 


### PR DESCRIPTION
Since 3.10: random.randrange() does no longer convert its arguments to
integers. Make the conversion explicit to avoid a deprecation warning