### PR TITLE
Support specifying the source IP address and/or port

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,14 @@ Flask-Mailman is configured through the standard Flask config API. A list of con
 
     Default: False.
 
+- **MAIL_SOURCE_ADDRESS**: The source IP address for the socket connection to the SMTP server. If None, then the OS default will be used. Specifying an explicit value for this configuration key may be useful in a machine with multiple network interfaces, if one interface in particular must be used when connecting to the mail server.
+
+    Default: None.
+
+- **MAIL_SOURCE_PORT**: The source TCP port for the socket connection to the SMTP server. If None, then the OS default will be used.
+
+    Default: None.
+
 Emails are managed through a *Mail* instance:
 ```python
 from flask import Flask

--- a/flask_mailman/__init__.py
+++ b/flask_mailman/__init__.py
@@ -203,7 +203,9 @@ class _Mail(_MailMixin):
         use_localtime,
         file_path,
         default_charset,
-        backend,
+        source_address,
+        source_port,
+        backend
     ):
         self.server = server
         self.port = port
@@ -218,6 +220,8 @@ class _Mail(_MailMixin):
         self.use_localtime = use_localtime
         self.file_path = file_path
         self.default_charset = default_charset
+        self.source_address = source_address
+        self.source_port = source_port
         self.backend = backend
 
 
@@ -255,6 +259,8 @@ class Mail(_MailMixin):
             config.get('MAIL_USE_LOCALTIME', False),
             config.get('MAIL_FILE_PATH'),
             config.get('MAIL_DEFAULT_CHARSET', 'utf-8'),
+            config.get('MAIL_SOURCE_ADDRESS'),
+            config.get('MAIL_SOURCE_PORT', 0),
             mail_backend,
         )
 

--- a/flask_mailman/backends/smtp.py
+++ b/flask_mailman/backends/smtp.py
@@ -45,10 +45,6 @@ class EmailBackend(BaseEmailBackend):
             raise ValueError(
                 "EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so only set " "one of those settings to True."
             )
-        if self.source_port is not None and self.source_address is None:
-            raise ValueError(
-                "MAIL_SOURCE_PORT is only valid when MAIL_SOURCE_ADDRESS is also set"
-            )
         self.connection = None
         self._lock = threading.RLock()
 
@@ -78,8 +74,8 @@ class EmailBackend(BaseEmailBackend):
                     'certfile': self.ssl_certfile,
                 }
             )
-        if self.source_address is not None:
-            connection_params['source_address'] = (self.source_address, self.source_port)
+        if self.source_address is not None or self.source_port is not None:
+            connection_params['source_address'] = ((self.source_address or ''), (self.source_port or 0))
         try:
             self.connection = self.connection_class(self.host, self.port, **connection_params)
 


### PR DESCRIPTION
A `source_address` argument is accepted by the `smtplib.SMTP` and `smtplib.SMTP_SSL` constructors. The argument is a pair comprising an IP address and a port number. Providing this argument is useful when more than one network interface is available to the app, but one in particular must be used when connecting to the SMTP server.

I propose to add support for this connection option to Flask-Mailman in the form of two new config properties, `MAIL_SOURCE_ADDRESS` and `MAIL_SOURCE_PORT`.

Apologies that I have not added mention of this feature to README.md as the contributing guidelines request, but I could not find a section in that file where it seemed to belong. I did add documentation for the two config properties to docs/index.md, however.