### PR TITLE
misssing last letter in package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ doc = [
     "mkdocs-include-markdown-plugin",
     "mkdocs-material",
     "mkdocstrings",
-    "mkdocs-material-extension",
+    "mkdocs-material-extensions",
     "mkdocs-autorefs"
     ]
 


### PR DESCRIPTION
causes package to be installed when using pip.