### PR TITLE
Fix Test PyPI action

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Build wheels and source tarball
         run: |
+          rm -rf dist/
           poetry version $(poetry version --short)-dev.$GITHUB_RUN_NUMBER
           poetry version --short
           poetry build


### PR DESCRIPTION
Fix the "HTTPError: 400 Bad Request from https://test.pypi.org/legacy/  Only one sdist may be uploaded per release." error. See details at https://github.com/waynerv/flask-mailman/actions/runs/5917600748/job/16046187621

This PR removes the unnecessary tarball generated by the tox command.