### PR TITLE
fix smtp compatibility with python 3.12

### DIFF
--- a/flask_mailman/backends/smtp.py
+++ b/flask_mailman/backends/smtp.py
@@ -76,7 +76,13 @@ class EmailBackend(BaseEmailBackend):
             # TLS/SSL are mutually exclusive, so only attempt TLS over
             # non-secure connections.
             if not self.use_ssl and self.use_tls:
-                self.connection.starttls()
+                if self.ssl_certfile:
+                    context = ssl.SSLContext().load_cert_chain(
+                        self.ssl_certfile, keyfile=self.ssl_keyfile
+                    )
+                else:
+                    context = None
+                self.connection.starttls(context=context)
             if self.username and self.password:
                 self.connection.login(self.username, self.password)
             return True

--- a/flask_mailman/backends/smtp.py
+++ b/flask_mailman/backends/smtp.py
@@ -76,7 +76,7 @@ class EmailBackend(BaseEmailBackend):
             # TLS/SSL are mutually exclusive, so only attempt TLS over
             # non-secure connections.
             if not self.use_ssl and self.use_tls:
-                self.connection.starttls(keyfile=self.ssl_keyfile, certfile=self.ssl_certfile)
+                self.connection.starttls()
             if self.username and self.password:
                 self.connection.login(self.username, self.password)
             return True


### PR DESCRIPTION
keyfile and certfile are now removed from python 3.12

This uses the context parameter to set the certs if needed.