### PR TITLE
Add `MAIL_SEND_OPTIONS` for `send_mail`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [1.0.1] - 2023-12-16
 
-- Add option `MAIL_SEND_OPTIONS` to support `SMTPUTF8`
-  ([#61](https://github.com/waynerv/flask-mailman/pull/61)).
+- Add configuration key `MAIL_SEND_OPTIONS` to support setting `mail_options` for `smtplib.SMTP.send_mail`
+  (e.g. `SMTPUTF8`) ([#61](https://github.com/waynerv/flask-mailman/pull/61)).
 
 ## [1.0.0] - 2023-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.1] - 2023-12-16
+
+- Add option `MAIL_SEND_OPTIONS` to support `SMTPUTF8`
+  ([#61](https://github.com/waynerv/flask-mailman/pull/61)).
+
 ## [1.0.0] - 2023-11-04
 
 - Drop Python 3.6 support.

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,10 @@ Flask-Mailman is configured through the standard Flask config API. A list of con
 
     Default: False.
 
+- **MAIL_SEND_OPTIONS**: `mail_options` for `smtplib.SMTP.sendmail`. If `SMTPUTF8` is included in `MAIL_SEND_OPTIONS`, and the server supports it, `from_mail` and `to` may contain non-ASCII characters.
+
+    Default: `[]`
+
 Emails are managed through a *Mail* instance:
 ```python
 from flask import Flask

--- a/flask_mailman/__init__.py
+++ b/flask_mailman/__init__.py
@@ -203,6 +203,7 @@ class _Mail(_MailMixin):
         use_localtime,
         file_path,
         default_charset,
+        mail_options,
         backend,
     ):
         self.server = server
@@ -218,6 +219,7 @@ class _Mail(_MailMixin):
         self.use_localtime = use_localtime
         self.file_path = file_path
         self.default_charset = default_charset
+        self.mail_options = mail_options
         self.backend = backend
 
 
@@ -255,6 +257,7 @@ class Mail(_MailMixin):
             config.get('MAIL_USE_LOCALTIME', False),
             config.get('MAIL_FILE_PATH'),
             config.get('MAIL_DEFAULT_CHARSET', 'utf-8'),
+            config.get('MAIL_SEND_OPTIONS', []),
             mail_backend,
         )
 

--- a/flask_mailman/backends/smtp.py
+++ b/flask_mailman/backends/smtp.py
@@ -138,7 +138,9 @@ class EmailBackend(BaseEmailBackend):
         recipients = [sanitize_address(addr, encoding) for addr in email_message.recipients()]
         message = email_message.message()
         try:
-            self.connection.sendmail(from_email, recipients, message.as_bytes(linesep='\r\n'))
+            self.connection.sendmail(
+                from_email, recipients, message.as_bytes(linesep='\r\n'), mail_options=self.mailman.mail_options
+            )
         except smtplib.SMTPException:
             if not self.fail_silently:
                 raise

--- a/flask_mailman/backends/smtp.py
+++ b/flask_mailman/backends/smtp.py
@@ -139,7 +139,10 @@ class EmailBackend(BaseEmailBackend):
         message = email_message.message()
         try:
             self.connection.sendmail(
-                from_email, recipients, message.as_bytes(linesep='\r\n'), mail_options=self.mailman.mail_options
+                from_email,
+                recipients,
+                message.as_bytes(linesep='\r\n'),
+                mail_options=self.mailman.mail_options,
             )
         except smtplib.SMTPException:
             if not self.fail_silently:


### PR DESCRIPTION
fixes #38 

Flask-Mailman does not set `mail_options` when calling `smtplib.SMTP.send_mail` in `backends/smtp.py#141`. When using a non-ASCII mailbox, the mail might be rejected by server if unsupported.

Add a new configuration `MAIL_SEND_OPTIONS` for `send_mail` to resolve this issue.

Note that I leave `CHANGELOG.md` unchanged since I'm not sure whether a new release should be created, as the fix above is quite small.