### PR TITLE
Fix SafeMIMEText.set_payload() crash on Python 3.13

### DIFF
--- a/flask_mailman/message.py
+++ b/flask_mailman/message.py
@@ -159,7 +159,7 @@ class SafeMIMEText(MIMEMixin, MIMEText):
 
     def set_payload(self, payload, charset=None):
         if charset == 'utf-8' and not isinstance(charset, Charset.Charset):
-            has_long_lines = any(len(line.encode()) > RFC5322_EMAIL_LINE_LENGTH_LIMIT for line in payload.splitlines())
+            has_long_lines = any(len(line.encode(errors="surrogateescape")) > RFC5322_EMAIL_LINE_LENGTH_LIMIT for line in payload.splitlines())
             # Quoted-Printable encoding has the side effect of shortening long
             # lines, if any (#22561).
             charset = utf8_charset_qp if has_long_lines else utf8_charset


### PR DESCRIPTION
See https://github.com/django/django/commit/b231bcd19e57267ce1fc21d42d46f0b65fdcfcf8